### PR TITLE
Bump sizeup-core to 0.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@oclif/plugin-plugins": "^3.6.1",
         "octokit": "^3.1.1",
         "simple-git": "^3.20.0",
-        "sizeup-core": "^0.1.4"
+        "sizeup-core": "^0.2.1"
       },
       "bin": {
         "sizeup": "bin/run"
@@ -11509,9 +11509,9 @@
       }
     },
     "node_modules/sizeup-core": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/sizeup-core/-/sizeup-core-0.1.4.tgz",
-      "integrity": "sha512-GCRG+BLwfVj/Z454etFLNCX3mWcmqWBTMQduvWXvFJmtI+XootZicn3L3wuGulBZ7aVE6NeY/7H9ixFMpTahfQ==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/sizeup-core/-/sizeup-core-0.2.1.tgz",
+      "integrity": "sha512-cZAggc3tA1nNrQc72RKJ98nJBPlatXMmFDLhJfTPP91mjefhMkrA+9X96pvzLiApLzbtosLa7NQdsraofi0zBQ==",
       "dependencies": {
         "minimatch": "^9.0.3",
         "parse-diff": "^0.11.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@oclif/plugin-plugins": "^3.6.1",
     "octokit": "^3.1.1",
     "simple-git": "^3.20.0",
-    "sizeup-core": "^0.1.4"
+    "sizeup-core": "^0.2.1"
   },
   "devDependencies": {
     "@oclif/test": "^2.5.3",


### PR DESCRIPTION
Full diff at https://github.com/lerebear/sizeup-core/compare/v0.1.4...v0.2.1, but major change is that this tool no longer accepts a configuration that includes a `threshold` configuration within the `categories` config.