### PR TITLE
Support arbitrary diff selection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,18 +23,12 @@ USAGE
   $ sizeup [DIFF] [-c <value>] [-t <value>] [-v]
 
 ARGUMENTS
-  DIFF
-      [default: @wip] An identifier for the diff to evalute.
-
-      The following identifiers are supported:
-
-      @wip - special identifier that denotes the modified files in the git working tree (i.e. the result of `git diff`)
-      @staged - special identifer that denotes the files in the git staging area (i.e. the result of `git diff --staged`)
-      <url> - The URL of a pull request on GitHub (e.g. "https://github.com/lerebear/sizeup-cli/pull/1")
+  DIFF  Either an arbitrary set of arguments/flags to be forwarded to `git diff` (in which case those arguments must
+        appear after "--") OR the URL of a pull request on GitHub (e.g. "https://github.com/lerebear/sizeup/pull/1")
 
 FLAGS
   -c, --config-path=<value>  Path to configuration file for the sizeup lib.
-                             For more details, see: https://github.com/lerebear/sizeup-core#configuration
+                             For more details, see: https://github.com/lerebear/sizeup#configuration
   -t, --token-path=<value>   Path to a file containing a GitHub API token.
                              If this flag is omitted and the `diff` argument is a URL, then this tool will prompt for a token instead.
   -v, --verbose              Explain scoring procedure in detail
@@ -43,15 +37,15 @@ DESCRIPTION
   Estimate how difficult a diff will be to review
 
 EXAMPLES
-  Estimate the reviewability of the diff of the modified files in the git working tree
+  Use the diff of the modified files in the git working tree
 
-    $ sizeup @wip
+    $ sizeup
 
-  Estimate the reviewability of the diff of the staged files in the git index using a custom configuration file
+  Use the diff between the current branch the merge target
 
-    $ sizeup @staged  --config-path experimental.yaml
+    $ sizeup -- --merge-base origin/main
 
-  (Re)compute the reviewability of the diff from an existing pull request
+  (Re)compute the score of an existing pull request using a custom configuration file
 
-    $ sizeup https://github.com/lerebear/sizeup-cli/pull/1
+    $ sizeup --config-path experimental.yaml https://github.com/lerebear/sizeup/pull/1
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,20 +5,21 @@ import {Octokit} from 'octokit'
 import * as fs from 'node:fs'
 
 export default class SizeUp extends Command {
+  static strict = false
   static description = 'Estimate how difficult a diff will be to review';
 
   static examples = [
     {
-      description: 'Estimate the reviewability of the diff of the modified files in the git working tree',
-      command: '<%= config.bin %> @wip',
+      description: 'Use the diff of the modified files in the git working tree',
+      command: '<%= config.bin %>',
     },
     {
-      description: 'Estimate the reviewability of the diff of the staged files in the git index using a custom configuration file',
-      command: '<%= config.bin %> @staged  --config-path experimental.yaml',
+      description: 'Use the diff between the current branch the merge target',
+      command: '<%= config.bin %> -- --merge-base origin/main',
     },
     {
-      description: '(Re)compute the reviewability of the diff from an existing pull request',
-      command: '<%= config.bin %> https://github.com/lerebear/sizeup/pull/1',
+      description: '(Re)compute the score of an existing pull request using a custom configuration file',
+      command: '<%= config.bin %> --config-path experimental.yaml https://github.com/lerebear/sizeup/pull/1',
     },
   ];
 
@@ -44,47 +45,57 @@ export default class SizeUp extends Command {
 
   static args = {
     diff: Args.string({
-      description: 'An identifier for the diff to evalute.\n\n' +
-        'The following identifiers are supported:\n\n' +
-        '  @wip - special identifier that denotes the modified files in the git working tree (i.e. the result of `git diff`)\n' +
-        '  @staged - special identifer that denotes the files in the git staging area (i.e. the result of `git diff --staged`)\n' +
-        '  <url> - The URL of a pull request on GitHub (e.g. "https://github.com/lerebear/sizeup/pull/1")',
+      description: (
+        'Either an arbitrary set of arguments/flags to be forwarded to `git diff` (in which case those arguments must\n' +
+        'appear after "--") OR the URL of a pull request on GitHub (e.g. "https://github.com/lerebear/sizeup/pull/1")'
+      ),
       required: false,
-      default: '@wip',
+      default: '',
     }),
   };
 
   async run(): Promise<void> {
     const {args, flags} = await this.parse(SizeUp)
+    const configChoice = flags['config-path'] ? `config from ${flags['config-path']}` : 'default config'
+    const {description, diff} = await this.fetchDiff(args, flags)
 
+    let score
+    if (diff) {
+      ux.action.start(`Evaluating the diff with the ${configChoice}`)
+      score = SizeUpCore.evaluate(diff, flags['config-path'])
+      ux.action.stop()
+      this.log(`Your diff scored ${score.result}${(score.category ? ` (${score.category.name})` : '')}.`)
+    } else {
+      this.log(`The diff ${description} was empty.`)
+    }
+
+    if (score && flags.verbose) {
+      this.log(`The score was computed as follows:\n${score.toString()}`)
+    }
+  }
+
+  private async fetchDiff(args: any, flags: any): Promise<{description: string, diff: string}> {
     const git = simpleGit()
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const [_scheme, _blank, _domain, owner, repo, _path, number] = args.diff.split('/')
-    let octokit: Octokit | undefined
-    let token: string | undefined
-    let diff: string | undefined
 
-    switch (args.diff) {
-    case '@wip':
+    let description: string
+    let diff: string | undefined
+    if (!args.diff) {
       ux.action.start('Retrieving diff from the working tree')
+      description = 'of the working tree'
       diff = await git.diff()
       ux.action.stop()
-      break
-    case '@stage':
-    case '@staged':
-    case '@cache':
-    case '@cached':
-      ux.action.start('Retrieving diff from the staging area')
-      diff = await git.diff(['--staged'])
-      ux.action.stop()
-      break
-    default:
-      token = flags['token-path'] ?
+    } else if (args.diff.startsWith('https://')) {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const [_scheme, _blank, _domain, owner, repo, _path, number] = args.diff.split('/')
+      const token = flags['token-path'] ?
         fs.readFileSync(flags['token-path']).toString().trim() :
         await ux.prompt('Please enter a GitHub API token', {type: 'hide'})
-      octokit = new Octokit({auth: token})
+      const octokit = new Octokit({auth: token})
+
+      ux.action.start(`Retrieving diff from ${args.diff}`)
+      description = `retrieved from ${args.diff}`
+
       try {
-        ux.action.start(`Retrieving diff from ${args.diff}`)
         diff = (
           await octokit.rest.pulls.get({
             owner: owner,
@@ -94,27 +105,23 @@ export default class SizeUp extends Command {
             mediaType: {format: 'diff'},
           })
         ).data as unknown as string
+        ux.action.stop()
       } catch (error) {
+        diff = ''
         const message = (error instanceof Error) ? error.message : ''
         ux.action.stop(`failed (${message.toLowerCase()})`)
-        return
-      }
-
-      ux.action.stop()
-      break
-    }
-
-    if (diff) {
-      ux.action.start(`Evaluating the diff with the ${flags['config-path'] ? `config from ${flags['config-path']}` : 'default config'}`)
-      const score = SizeUpCore.evaluate(diff!, flags['config-path'])
-      ux.action.stop()
-      this.log(`Your diff scored ${score.result}${(score.category ? ` (${score.category.name})` : '')}.`)
-
-      if (flags.verbose) {
-        this.log(`The score was computed as follows:\n${score.toString()}`)
       }
     } else {
-      this.log(`The diff identified by '${args.diff}' was empty.`)
+      const diffArgs = this.argv.join(' ').split(/\s+--\s+/)[1].split(/\s+/)
+      description = `identified by \`git diff ${diffArgs.join(' ')}\``
+      ux.action.start(`Retrieving diff using ${description}`)
+      diff = await git.diff(diffArgs)
+      ux.action.stop()
+    }
+
+    return {
+      description,
+      diff,
     }
   }
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -8,6 +8,6 @@ describe('sizeup', () => {
   .do(() => sizeup.run([]))
   .it('runs sizeup cmd', ctx => {
     expect(ctx.error).to.be.undefined
-    expect(ctx.stdout).to.match(/^(Your diff scored|The diff identified by '@wip' was empty)/)
+    expect(ctx.stdout).to.match(/^(Your diff scored|The diff of the working tree was empty)/)
   })
 })


### PR DESCRIPTION
Closes #1.

This adds support for identifying a diff using arbitrary arguments that are forwarded to `git diff`. It also removes the old `@wip` and `@staged` aliases in favour of the new, more general diff selection mechanism.