### PR TITLE
Bump `sizeup-core` to `0.3.1`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11684,9 +11684,9 @@
       }
     },
     "node_modules/sizeup-core": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/sizeup-core/-/sizeup-core-0.3.0.tgz",
-      "integrity": "sha512-fXHgBCG7r9GDrIK0MFIJX/IUX3QS1CxWorLrS/j5cDYZrhargslRevlPr8dWwylA5ps/iQs/6147ApKOHqO0SQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/sizeup-core/-/sizeup-core-0.3.1.tgz",
+      "integrity": "sha512-W1fQ7m2DD5Fy+i//WPvtwMwZLEhPO40MqRLljf+wwsKr7c5X3r+v7JskufefrBpJR50F7/jZBlFfCmPOsyWYJg==",
       "dependencies": {
         "minimatch": "^9.0.3",
         "parse-diff": "^0.11.1",


### PR DESCRIPTION
This pulls in a fix that ensures that both additions and deletions are counted by the `tests` evaluation feature (as opposed to only additions).