### PR TITLE
Fix diff argument parsing.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -112,7 +112,7 @@ export default class SizeUp extends Command {
         ux.action.stop(`failed (${message.toLowerCase()})`)
       }
     } else {
-      const diffArgs = this.argv.join(' ').split(/\s+--\s+/)[1].split(/\s+/)
+      const diffArgs = this.argv.join(' ').split(/\s*--\s+/)[1].split(/\s+/)
       description = `identified by \`git diff ${diffArgs.join(' ')}\``
       ux.action.start(`Retrieving diff using ${description}`)
       diff = await git.diff(diffArgs)

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -6,8 +6,35 @@ describe('sizeup', () => {
   .stderr()
   .stdout()
   .do(() => sizeup.run([]))
-  .it('runs sizeup cmd', ctx => {
+  .it('runs sizeup command successfully with no flags or arguments', ctx => {
     expect(ctx.error).to.be.undefined
     expect(ctx.stdout).to.match(/^(Your diff scored|The diff of the working tree was empty)/)
+  })
+
+  test
+  .stderr()
+  .stdout()
+  .do(() => sizeup.run(['-v']))
+  .it('runs sizeup command successfully with flags but no arguments', ctx => {
+    expect(ctx.error).to.be.undefined
+    expect(ctx.stdout).to.match(/^(Your diff scored|The diff of the working tree was empty)/)
+  })
+
+  test
+  .stderr()
+  .stdout()
+  .do(() => sizeup.run(['--', '--staged']))
+  .it('runs sizeup command successfully with arguments but no flags', ctx => {
+    expect(ctx.error).to.be.undefined
+    expect(ctx.stdout).to.match(/^(Your diff scored|The diff identified by `git diff --staged` was empty)/)
+  })
+
+  test
+  .stderr()
+  .stdout()
+  .do(() => sizeup.run(['-v', '--', '--staged']))
+  .it('runs sizeup command successfully with flags and arguments', ctx => {
+    expect(ctx.error).to.be.undefined
+    expect(ctx.stdout).to.match(/^(Your diff scored|The diff identified by `git diff --staged` was empty)/)
   })
 })


### PR DESCRIPTION
Previously, we would throw an exception when we attempted to parse diff arguments that were not also accompanied by use of a flag on the sizeup command. This fixes that so that arguments can be provided without any flags.