### PR TITLE
Adjust config to fix compilation of dependency from inquirer

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "esModuleInterop": true,
     "importHelpers": true,
     "module": "commonjs",
     "outDir": "dist",


### PR DESCRIPTION
Without this change, I was receiving an error like `@types/mute-stream/index"' can only be default-imported using the 'esModuleInterop' flag` after attempting `npm publish`. This seems to have been due to the inclusion of `@inquirer/password` in https://github.com/lerebear/sizeup-cli/pull/21. This is a speculative attempt to fix that problem.